### PR TITLE
Add Endpoint Option for Local Development

### DIFF
--- a/lib/adapter/sns-adapter.js
+++ b/lib/adapter/sns-adapter.js
@@ -5,12 +5,23 @@ module.exports = exports = class SNSAdapter {
 
   constructor(options = {}) {
     let credentials = null
+    let endpoint = null
+    options.region = options.region || 'us-east-1'
 
     if (options.awsAccessKey && options.awsSecretKey) {
       credentials = { accessKeyId: options.awsAccessKey, secretAccessKey: options.awsSecretKey }
     }
 
-    this.#snsClient = options.snsClient || new SNSClient({ region: options.region || 'us-east-1', credentials })
+    if (options.endpoint) {
+      endpoint = options.endpoint // Only used in local development
+    }
+
+    this.#snsClient = options.snsClient || new SNSClient({ region: options.region, credentials, endpoint })
+  }
+
+  // Getter for snsClient - mostly for unit testing
+  get getSNSClient() {
+    return this.#snsClient
   }
 
   async publish(topicArn, message, options = {}) {

--- a/test/sns-adapter.test.js
+++ b/test/sns-adapter.test.js
@@ -88,4 +88,19 @@ describe('SNSAdapter', () => {
 
     consoleErrorStub.restore()
   })
+
+  it('creates a new SNSAdapter with a custom endpoint', async () => {
+    const endpoint = 'http://localhost:4575' // LocalStack SNS endpoint for local testing
+    const customSNSAdapter = new SNSAdapter({ endpoint })
+
+    expect(customSNSAdapter).to.exist()
+    expect(customSNSAdapter).to.be.an.instanceof(SNSAdapter)
+
+    // Check that the SNSClient was created with the correct endpoint
+    const client = customSNSAdapter.getSNSClient
+    const actualEndpoint = await client.config.endpoint()
+
+    expect(actualEndpoint.hostname).to.equal('localhost')
+    expect(actualEndpoint.port).to.equal(4575)
+  })
 })


### PR DESCRIPTION
This PR introduces a new feature that allows developers to specify a custom endpoint for the SNS client. This is particularly useful for local development and testing, where developers might want to use a local mock SNS service instead of the real AWS service.

Changes:

- Added an endpoint option to the SNSAdapter constructor. This option is used when creating the SNSClient.
- Updated the SNSAdapter class to use the endpoint option if it is provided.
- Added a new test case to verify that the SNSAdapter correctly uses the endpoint option when it is provided.

Testing:

All existing tests pass, and a new test was added to check the new functionality. The new test creates a SNSAdapter with a custom endpoint and verifies that the SNSClient uses the correct endpoint.